### PR TITLE
geom_alt props

### DIFF
--- a/data/421/188/955/421188955.geojson
+++ b/data/421/188/955/421188955.geojson
@@ -221,7 +221,8 @@
     "qs:woe_id":1050900,
     "src:geom":"quattroshapes",
     "src:geom_alt":[
-        "quattroshapes_pg"
+        "quattroshapes_pg",
+        "naturalearth"
     ],
     "wd:wordcount":674,
     "wof:belongsto":[
@@ -239,6 +240,10 @@
     },
     "wof:country":"VU",
     "wof:created":1459009589,
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "naturalearth"
+    ],
     "wof:geomhash":"de155460c7a76324df3ffb509c4eaf7f",
     "wof:hierarchy":[
         {
@@ -249,7 +254,7 @@
         }
     ],
     "wof:id":421188955,
-    "wof:lastmodified":1561830131,
+    "wof:lastmodified":1582379151,
     "wof:name":"Luganville",
     "wof:parent_id":85680875,
     "wof:placetype":"locality",

--- a/data/856/322/63/85632263.geojson
+++ b/data/856/322/63/85632263.geojson
@@ -820,6 +820,7 @@
     "qs:source":"US State Department, with Natural Earth mods",
     "src:geom":"quattroshapes",
     "src:geom_alt":[
+        "naturalearth",
         "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -875,6 +876,10 @@
     },
     "wof:country":"VU",
     "wof:country_alpha3":"VUT",
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6",
+        "naturalearth"
+    ],
     "wof:geomhash":"7ef9c2584cf73eecb4ec2c7875c633d6",
     "wof:hierarchy":[
         {
@@ -893,7 +898,7 @@
         "eng",
         "fra"
     ],
-    "wof:lastmodified":1566652536,
+    "wof:lastmodified":1582379149,
     "wof:name":"Vanuatu",
     "wof:parent_id":102191583,
     "wof:placetype":"country",

--- a/data/856/322/63/85632263.geojson
+++ b/data/856/322/63/85632263.geojson
@@ -820,7 +820,6 @@
     "qs:source":"US State Department, with Natural Earth mods",
     "src:geom":"quattroshapes",
     "src:geom_alt":[
-        "naturalearth",
         "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -898,7 +897,7 @@
         "eng",
         "fra"
     ],
-    "wof:lastmodified":1582379149,
+    "wof:lastmodified":1583259862,
     "wof:name":"Vanuatu",
     "wof:parent_id":102191583,
     "wof:placetype":"country",

--- a/data/890/416/453/890416453.geojson
+++ b/data/890/416/453/890416453.geojson
@@ -492,6 +492,10 @@
     },
     "wof:country":"VU",
     "wof:created":1469051135,
+    "wof:geom_alt":[
+        "unknown",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bdb1a8f9d22294bac07b645a848ce655",
     "wof:hierarchy":[
         {
@@ -502,7 +506,7 @@
         }
     ],
     "wof:id":890416453,
-    "wof:lastmodified":1566652635,
+    "wof:lastmodified":1582379152,
     "wof:name":"Port-Vila",
     "wof:parent_id":85680893,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.