### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/112/582/248/7/1125822487.geojson
+++ b/data/112/582/248/7/1125822487.geojson
@@ -22,8 +22,14 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Norsup"
+    ],
     "name:ceb_x_preferred":[
         "\u00celot Norsoup"
+    ],
+    "name:deu_x_preferred":[
+        "Norsup"
     ],
     "name:eng_x_preferred":[
         "Norsup"
@@ -42,6 +48,9 @@
     ],
     "name:und_x_variant":[
         "Norsoup"
+    ],
+    "name:zho_x_preferred":[
+        "\u8afe\u8607\u666e"
     ],
     "qs_pg:aaroncc":"VU",
     "qs_pg:gn_country":"VU",
@@ -80,7 +89,7 @@
         }
     ],
     "wof:id":1125822487,
-    "wof:lastmodified":1566652635,
+    "wof:lastmodified":1690921637,
     "wof:name":"Norsup",
     "wof:parent_id":85680883,
     "wof:placetype":"locality",

--- a/data/114/190/694/9/1141906949.geojson
+++ b/data/114/190/694/9/1141906949.geojson
@@ -21,6 +21,12 @@
     "name:ara_x_preferred":[
         "\u0644\u0648\u063a\u0627\u0646\u0641\u064a\u0644"
     ],
+    "name:arz_x_preferred":[
+        "\u0644\u0648\u062c\u0627\u0646\u0641\u064a\u0644"
+    ],
+    "name:ast_x_preferred":[
+        "Luganville"
+    ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u041b\u0443\u0433\u0430\u043d\u0432\u0456\u043b"
     ],
@@ -51,10 +57,16 @@
     "name:eng_x_preferred":[
         "Luganville"
     ],
+    "name:fas_x_preferred":[
+        "\u0644\u06af\u0627\u0646\u0648\u06cc\u0644"
+    ],
     "name:fin_x_preferred":[
         "Luganville"
     ],
     "name:fra_x_preferred":[
+        "Luganville"
+    ],
+    "name:frr_x_preferred":[
         "Luganville"
     ],
     "name:heb_x_preferred":[
@@ -111,6 +123,9 @@
     "name:rus_x_preferred":[
         "\u041b\u0443\u0433\u0430\u043d\u0432\u0438\u043b\u043b"
     ],
+    "name:rus_x_variant":[
+        "\u041b\u044e\u0433\u0430\u043d\u0432\u0438\u043b\u044c"
+    ],
     "name:spa_x_preferred":[
         "Luganville"
     ],
@@ -121,6 +136,9 @@
         "\u041b\u0443\u0433\u0430\u043d\u0432\u0438\u043b"
     ],
     "name:swe_x_preferred":[
+        "Luganville"
+    ],
+    "name:tur_x_preferred":[
         "Luganville"
     ],
     "name:ukr_x_preferred":[
@@ -264,7 +282,7 @@
         }
     ],
     "wof:id":1141906949,
-    "wof:lastmodified":1636504684,
+    "wof:lastmodified":1690921637,
     "wof:name":"Luganville",
     "wof:parent_id":85680875,
     "wof:placetype":"locality",

--- a/data/421/202/441/421202441.geojson
+++ b/data/421/202/441/421202441.geojson
@@ -17,10 +17,16 @@
     "mz:is_current":1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ast_x_preferred":[
+        "Lenakel"
+    ],
     "name:ceb_x_preferred":[
         "L\u00e9nakel"
     ],
     "name:ces_x_preferred":[
+        "Lenakel"
+    ],
+    "name:deu_x_preferred":[
         "Lenakel"
     ],
     "name:eng_x_preferred":[
@@ -28,6 +34,9 @@
     ],
     "name:fra_x_preferred":[
         "Lenakel"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30ec\u30ca\u30b1\u30eb"
     ],
     "name:lit_x_preferred":[
         "Lenakelis"
@@ -89,7 +98,7 @@
         }
     ],
     "wof:id":421202441,
-    "wof:lastmodified":1566652634,
+    "wof:lastmodified":1690921634,
     "wof:name":"Lenakel",
     "wof:parent_id":85680881,
     "wof:placetype":"locality",

--- a/data/421/203/531/421203531.geojson
+++ b/data/421/203/531/421203531.geojson
@@ -20,6 +20,9 @@
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0406\u0441\u0430\u043d\u0433\u0435\u043b"
     ],
+    "name:bel_x_variant":[
+        "\u0406\u0441\u0430\u043d\u0433\u0435\u043b"
+    ],
     "name:bis_x_preferred":[
         "Isangel"
     ],
@@ -132,7 +135,7 @@
         }
     ],
     "wof:id":421203531,
-    "wof:lastmodified":1566652634,
+    "wof:lastmodified":1690921634,
     "wof:name":"Isangel",
     "wof:parent_id":85680881,
     "wof:placetype":"locality",

--- a/data/856/322/63/85632263.geojson
+++ b/data/856/322/63/85632263.geojson
@@ -46,6 +46,12 @@
     "name:amh_x_preferred":[
         "\u126b\u1291\u12a0\u1271"
     ],
+    "name:ami_x_preferred":[
+        "Vanuatu"
+    ],
+    "name:anp_x_preferred":[
+        "\u0935\u0928\u0941\u0906\u091f\u0941"
+    ],
     "name:ara_x_preferred":[
         "\u0641\u0627\u0646\u0648\u0627\u062a\u0648"
     ],
@@ -64,6 +70,9 @@
     "name:ast_x_preferred":[
         "Vanuatu"
     ],
+    "name:avk_x_preferred":[
+        "Vanuatua"
+    ],
     "name:azb_x_preferred":[
         "\u0648\u0627\u0646\u0648\u0627\u062a\u0648"
     ],
@@ -76,6 +85,9 @@
     "name:bam_x_preferred":[
         "Vanuwatu"
     ],
+    "name:ban_x_preferred":[
+        "Vanuatu"
+    ],
     "name:bcl_x_preferred":[
         "Banuatu"
     ],
@@ -84,6 +96,9 @@
     ],
     "name:ben_x_preferred":[
         "\u09ad\u09be\u09a8\u09c1\u09af\u09bc\u09be\u099f\u09c1"
+    ],
+    "name:ben_x_variant":[
+        "\u09ad\u09be\u09a8\u09c1\u09af\u09bc\u09be\u09a4\u09c1"
     ],
     "name:bho_x_preferred":[
         "\u0935\u093e\u0928\u0942\u0906\u0924\u0942"
@@ -133,6 +148,12 @@
     "name:che_x_preferred":[
         "\u0412\u0430\u043d\u0443\u0430\u0442\u0443"
     ],
+    "name:chr_x_preferred":[
+        "\u13e9\u13c2\u13a4\u13e9\u13da"
+    ],
+    "name:chy_x_preferred":[
+        "Vanuatu"
+    ],
     "name:ckb_x_preferred":[
         "\u06a4\u0627\u0646\u0648\u0627\u062a\u0648\u0648"
     ],
@@ -141,6 +162,9 @@
     ],
     "name:cor_x_preferred":[
         "Vanuatu"
+    ],
+    "name:cos_x_preferred":[
+        "Vanatu"
     ],
     "name:crh_x_preferred":[
         "Vanuatu"
@@ -248,6 +272,9 @@
     "name:ful_x_preferred":[
         "Wanuwaatuu"
     ],
+    "name:ful_x_variant":[
+        "Fanuwatu"
+    ],
     "name:gag_x_preferred":[
         "Vanuatu"
     ],
@@ -269,6 +296,12 @@
     "name:gom_x_preferred":[
         "\u0935\u0928\u0941\u0906\u091f\u0941"
     ],
+    "name:gpe_x_preferred":[
+        "Vanuatu"
+    ],
+    "name:grn_x_preferred":[
+        "Vanu\u00e1tu"
+    ],
     "name:gsw_x_preferred":[
         "Vanuatu"
     ],
@@ -286,6 +319,9 @@
     ],
     "name:hau_x_preferred":[
         "Banuwatu"
+    ],
+    "name:hau_x_variant":[
+        "Vanuatu"
     ],
     "name:hbs_x_preferred":[
         "Vanuatu"
@@ -320,8 +356,14 @@
     "name:hye_x_preferred":[
         "\u054e\u0561\u0576\u0578\u0582\u0561\u057f\u0578\u0582"
     ],
+    "name:hyw_x_preferred":[
+        "\u054e\u0561\u0576\u0578\u0582\u0561\u0569\u0578\u0582"
+    ],
     "name:ido_x_preferred":[
         "Vanuatu"
+    ],
+    "name:iku_x_preferred":[
+        "\u1559\u14c4\u140a\u1450"
     ],
     "name:ile_x_preferred":[
         "Vanuatu"
@@ -375,6 +417,9 @@
     "name:kaz_x_preferred":[
         "\u0412\u0430\u043d\u0443\u0430\u0442\u0443"
     ],
+    "name:khm_x_preferred":[
+        "\u179c\u17c9\u17b6\u1793\u17bc\u17a2\u17b6\u1791\u17bc"
+    ],
     "name:kik_x_preferred":[
         "Vanuatu"
     ],
@@ -420,6 +465,9 @@
     "name:lit_x_preferred":[
         "Vanuatu"
     ],
+    "name:lld_x_preferred":[
+        "Vanuatu"
+    ],
     "name:lmo_x_preferred":[
         "Vanuatu"
     ],
@@ -447,6 +495,12 @@
     "name:mar_x_variant":[
         "\u0935\u093e\u0928\u094c\u091f\u0941"
     ],
+    "name:mhr_x_preferred":[
+        "\u0412\u0430\u043d\u0443\u0430\u0442\u0443"
+    ],
+    "name:min_x_preferred":[
+        "Vanuatu"
+    ],
     "name:mkd_x_preferred":[
         "\u0412\u0430\u043d\u0443\u0430\u0442\u0443"
     ],
@@ -462,8 +516,17 @@
     "name:mlt_x_preferred":[
         "Vanwatu"
     ],
+    "name:mlt_x_variant":[
+        "Vanuatu"
+    ],
+    "name:mni_x_preferred":[
+        "\uabda\uabe5\uabc5\uabe8\uabd1\uabe5\uabc7\uabe8"
+    ],
     "name:mon_x_preferred":[
         "\u0412\u0430\u043d\u0443\u0430\u0442\u0443"
+    ],
+    "name:mri_x_preferred":[
+        "Whenuat\u016b"
     ],
     "name:mrj_x_preferred":[
         "\u0412\u0430\u043d\u0443\u0430\u0442\u0443"
@@ -485,6 +548,9 @@
     ],
     "name:nav_x_preferred":[
         "Bano\u02bc\u00e1\u00e1t\u02bcoo"
+    ],
+    "name:nav_x_variant":[
+        "Adeeshzhahnii Bik\u00e9yah"
     ],
     "name:nde_x_preferred":[
         "Vhanuatu"
@@ -511,6 +577,9 @@
         "Vanuatu"
     ],
     "name:nor_x_preferred":[
+        "Vanuatu"
+    ],
+    "name:nov_x_preferred":[
         "Vanuatu"
     ],
     "name:oci_x_preferred":[
@@ -594,6 +663,9 @@
     "name:sgs_x_preferred":[
         "Vanuatu"
     ],
+    "name:shn_x_preferred":[
+        "\u1019\u102d\u1030\u1004\u103a\u1038\u101d\u1085\u107c\u103a\u1087\u107c\u1030\u1038\u101d\u1083\u1087\u1011\u1030\u1087"
+    ],
     "name:sin_x_preferred":[
         "\u0dc0\u0db1\u0dd4\u0dc0\u0dcf\u0da7\u0dd4"
     ],
@@ -606,7 +678,13 @@
     "name:sme_x_preferred":[
         "Vanuatu"
     ],
+    "name:smn_x_preferred":[
+        "Vanuatu"
+    ],
     "name:smo_x_preferred":[
+        "Vanuatu"
+    ],
+    "name:sms_x_preferred":[
         "Vanuatu"
     ],
     "name:sna_x_preferred":[
@@ -617,6 +695,9 @@
     ],
     "name:som_x_preferred":[
         "Vanuatu"
+    ],
+    "name:som_x_variant":[
+        "Fanwatu"
     ],
     "name:spa_x_preferred":[
         "Vanuatu"
@@ -680,6 +761,9 @@
     "name:tir_x_preferred":[
         "\u126b\u1291\u12a0\u1271"
     ],
+    "name:tok_x_preferred":[
+        "ma Wanuwatu"
+    ],
     "name:ton_x_preferred":[
         "Vanuatu"
     ],
@@ -694,6 +778,9 @@
     ],
     "name:tur_x_variant":[
         "Vanuatu Cumhuriyeti"
+    ],
+    "name:udm_x_preferred":[
+        "\u0412\u0430\u043d\u0443\u0430\u0442\u0443"
     ],
     "name:uig_x_preferred":[
         "\u06cb\u0627\u0646\u06c7\u0626\u0627\u062a\u06c7"
@@ -712,6 +799,9 @@
         "\u0648\u06cc\u0646\u0648\u0622\u0679\u0648"
     ],
     "name:uzb_x_preferred":[
+        "Vanuatu"
+    ],
+    "name:vec_x_preferred":[
         "Vanuatu"
     ],
     "name:vep_x_preferred":[
@@ -1009,7 +1099,7 @@
         "eng",
         "fra"
     ],
-    "wof:lastmodified":1617827637,
+    "wof:lastmodified":1690921630,
     "wof:name":"Vanuatu",
     "wof:parent_id":102191583,
     "wof:placetype":"country",

--- a/data/856/808/71/85680871.geojson
+++ b/data/856/808/71/85680871.geojson
@@ -113,6 +113,9 @@
     "name:kor_x_preferred":[
         "\ud1a0\ub974\ubc14 \uc8fc"
     ],
+    "name:kor_x_variant":[
+        "\ud1a0\ub974\ubc14\uc8fc"
+    ],
     "name:lav_x_preferred":[
         "Torbas province"
     ],
@@ -122,11 +125,17 @@
     "name:mar_x_preferred":[
         "\u091f\u094b\u0930\u092c\u093e \u092a\u094d\u0930\u093e\u0902\u0924"
     ],
+    "name:mkd_x_preferred":[
+        "\u0422\u043e\u0440\u0431\u0430"
+    ],
     "name:mrj_x_preferred":[
         "\u0422\u043e\u0440\u0431\u0430"
     ],
     "name:msa_x_preferred":[
         "Torba Province"
+    ],
+    "name:nan_x_preferred":[
+        "Torba S\u00e9ng"
     ],
     "name:nld_x_preferred":[
         "Torba"
@@ -145,6 +154,9 @@
     ],
     "name:sin_x_preferred":[
         "\u0da7\u0ddc\u0dbb\u0dca\u0db6\u0dcf \u0db4\u0dc5\u0dcf\u0dad"
+    ],
+    "name:slv_x_preferred":[
+        "Torba"
     ],
     "name:spa_x_preferred":[
         "Torba"
@@ -301,7 +313,7 @@
         "eng",
         "fra"
     ],
-    "wof:lastmodified":1636504683,
+    "wof:lastmodified":1690921633,
     "wof:name":"Torba",
     "wof:parent_id":85632263,
     "wof:placetype":"region",

--- a/data/856/808/75/85680875.geojson
+++ b/data/856/808/75/85680875.geojson
@@ -113,6 +113,9 @@
     "name:kor_x_preferred":[
         "\uc0b0\ub9c8 \uc8fc"
     ],
+    "name:kor_x_variant":[
+        "\uc0b0\ub9c8\uc8fc"
+    ],
     "name:lav_x_preferred":[
         "Sanma province"
     ],
@@ -130,6 +133,9 @@
     ],
     "name:msa_x_preferred":[
         "Sanma Province"
+    ],
+    "name:nan_x_preferred":[
+        "Sanma S\u00e9ng"
     ],
     "name:nld_x_preferred":[
         "Sanma"
@@ -307,7 +313,7 @@
         "eng",
         "fra"
     ],
-    "wof:lastmodified":1636504682,
+    "wof:lastmodified":1690921631,
     "wof:name":"Sanma",
     "wof:parent_id":85632263,
     "wof:placetype":"region",

--- a/data/856/808/81/85680881.geojson
+++ b/data/856/808/81/85680881.geojson
@@ -43,6 +43,9 @@
     "name:bul_x_preferred":[
         "\u0422\u0430\u0444\u0435\u0430"
     ],
+    "name:cat_x_preferred":[
+        "Taf\u00e9a"
+    ],
     "name:ceb_x_preferred":[
         "Tafea Province"
     ],
@@ -112,6 +115,9 @@
     "name:kor_x_preferred":[
         "\ud0c0\ud398\uc544 \uc8fc"
     ],
+    "name:kor_x_variant":[
+        "\ud0c0\ud398\uc544\uc8fc"
+    ],
     "name:lav_x_preferred":[
         "Tafea province"
     ],
@@ -121,11 +127,17 @@
     "name:mar_x_preferred":[
         "\u091f\u092b\u093f\u092f\u093e \u092a\u094d\u0930\u093e\u0902\u0924"
     ],
+    "name:mkd_x_preferred":[
+        "\u0422\u0430\u0444\u0435\u0430"
+    ],
     "name:mrj_x_preferred":[
         "\u0422\u0430\u0444\u0435\u0430"
     ],
     "name:msa_x_preferred":[
         "Tafea Province"
+    ],
+    "name:nan_x_preferred":[
+        "Tafea S\u00e9ng"
     ],
     "name:nld_x_preferred":[
         "Tafea"
@@ -295,7 +307,7 @@
         "eng",
         "fra"
     ],
-    "wof:lastmodified":1636504683,
+    "wof:lastmodified":1690921632,
     "wof:name":"Tafea",
     "wof:parent_id":85632263,
     "wof:placetype":"region",

--- a/data/856/808/83/85680883.geojson
+++ b/data/856/808/83/85680883.geojson
@@ -83,6 +83,9 @@
     "name:heb_x_preferred":[
         "\u05de\u05dc\u05d0\u05e0\u05d6'\u05d4"
     ],
+    "name:heb_x_variant":[
+        "\u05de\u05d7\u05d5\u05d6 \u05de\u05d0\u05dc\u05d0\u05de\u05e4\u05d4"
+    ],
     "name:hin_x_preferred":[
         "\u092e\u0932\u093e\u092e\u094d\u092a\u093e \u092a\u094d\u0930\u093e\u0902\u0924"
     ],
@@ -113,6 +116,9 @@
     "name:kor_x_preferred":[
         "\ub9d0\ub78c\ud30c \uc8fc"
     ],
+    "name:kor_x_variant":[
+        "\ub9d0\ub78c\ud30c\uc8fc"
+    ],
     "name:lav_x_preferred":[
         "Malampas province"
     ],
@@ -130,6 +136,9 @@
     ],
     "name:msa_x_preferred":[
         "Daerah Malampa"
+    ],
+    "name:nan_x_preferred":[
+        "Malampa S\u00e9ng"
     ],
     "name:nld_x_preferred":[
         "Malampa"
@@ -301,7 +310,7 @@
         "eng",
         "fra"
     ],
-    "wof:lastmodified":1636504683,
+    "wof:lastmodified":1690921632,
     "wof:name":"Malampa",
     "wof:parent_id":85632263,
     "wof:placetype":"region",

--- a/data/856/808/87/85680887.geojson
+++ b/data/856/808/87/85680887.geojson
@@ -47,6 +47,9 @@
     "name:ceb_x_preferred":[
         "Penama Province"
     ],
+    "name:ces_x_preferred":[
+        "Penama"
+    ],
     "name:dan_x_preferred":[
         "Penama Province"
     ],
@@ -110,6 +113,9 @@
     "name:kor_x_preferred":[
         "\ud398\ub098\ub9c8 \uc8fc"
     ],
+    "name:kor_x_variant":[
+        "\ud398\ub098\ub9c8\uc8fc"
+    ],
     "name:lav_x_preferred":[
         "Penamas province"
     ],
@@ -127,6 +133,9 @@
     ],
     "name:msa_x_preferred":[
         "Wilayah Penama"
+    ],
+    "name:nan_x_preferred":[
+        "Penama S\u00e9ng"
     ],
     "name:nld_x_preferred":[
         "Penama"
@@ -296,7 +305,7 @@
         "eng",
         "fra"
     ],
-    "wof:lastmodified":1636504682,
+    "wof:lastmodified":1690921631,
     "wof:name":"Penama",
     "wof:parent_id":85632263,
     "wof:placetype":"region",

--- a/data/856/808/93/85680893.geojson
+++ b/data/856/808/93/85680893.geojson
@@ -65,6 +65,9 @@
     "name:epo_x_preferred":[
         "Shefa"
     ],
+    "name:est_x_preferred":[
+        "Shefa provints"
+    ],
     "name:fas_x_preferred":[
         "\u0634\u0641\u0627"
     ],
@@ -95,6 +98,9 @@
     "name:hun_x_preferred":[
         "Shefa"
     ],
+    "name:hye_x_preferred":[
+        "\u0547\u0565\u0586\u0561"
+    ],
     "name:ind_x_preferred":[
         "Provinsi Shefa"
     ],
@@ -116,6 +122,9 @@
     "name:kor_x_preferred":[
         "\uc170\ud30c \uc8fc"
     ],
+    "name:kor_x_variant":[
+        "\uc170\ud30c\uc8fc"
+    ],
     "name:lav_x_preferred":[
         "\u0160efas province"
     ],
@@ -125,11 +134,17 @@
     "name:mar_x_preferred":[
         "\u0936\u0947\u092b\u093e \u092a\u094d\u0930\u093e\u0902\u0924"
     ],
+    "name:mkd_x_preferred":[
+        "\u0428\u0435\u0444\u0430"
+    ],
     "name:mrj_x_preferred":[
         "\u0428\u0435\u0444\u0430"
     ],
     "name:msa_x_preferred":[
         "Shefa Province"
+    ],
+    "name:nan_x_preferred":[
+        "Shefa S\u00e9ng"
     ],
     "name:nld_x_preferred":[
         "Shefa"
@@ -299,7 +314,7 @@
         "eng",
         "fra"
     ],
-    "wof:lastmodified":1636504682,
+    "wof:lastmodified":1690921630,
     "wof:name":"Shefa",
     "wof:parent_id":85632263,
     "wof:placetype":"region",

--- a/data/890/413/115/890413115.geojson
+++ b/data/890/413/115/890413115.geojson
@@ -19,6 +19,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:ast_x_preferred":[
+        "Lakatoro"
+    ],
     "name:bul_x_preferred":[
         "\u041b\u0430\u043a\u0430\u0442\u043e\u0440\u043e"
     ],
@@ -46,6 +49,9 @@
     "name:jpn_x_preferred":[
         "\u30e9\u30ab\u30c8\u30ed"
     ],
+    "name:kor_x_preferred":[
+        "\ub77c\uce74\ud1a0\ub85c"
+    ],
     "name:lit_x_preferred":[
         "Lakatoras"
     ],
@@ -62,6 +68,9 @@
         "Lakatoro"
     ],
     "name:rus_x_preferred":[
+        "\u041b\u0430\u043a\u0430\u0442\u043e\u0440\u043e"
+    ],
+    "name:ukr_x_preferred":[
         "\u041b\u0430\u043a\u0430\u0442\u043e\u0440\u043e"
     ],
     "name:urd_x_preferred":[
@@ -102,7 +111,7 @@
         }
     ],
     "wof:id":890413115,
-    "wof:lastmodified":1566652634,
+    "wof:lastmodified":1690921635,
     "wof:name":"Lakatoro",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/416/453/890416453.geojson
+++ b/data/890/416/453/890416453.geojson
@@ -37,10 +37,19 @@
     "name:arg_x_preferred":[
         "Port Vila"
     ],
+    "name:ary_x_preferred":[
+        "\u067e\u0648\u0631\u062a \u06a4\u064a\u0644\u0627"
+    ],
+    "name:arz_x_preferred":[
+        "\u0628\u0648\u0631\u062a \u0641\u064a\u0644\u0627"
+    ],
     "name:ast_x_preferred":[
         "Port Vila"
     ],
     "name:aze_x_preferred":[
+        "Port Vila"
+    ],
+    "name:ban_x_preferred":[
         "Port Vila"
     ],
     "name:bel_x_preferred":[
@@ -128,6 +137,9 @@
         "Port Fila"
     ],
     "name:gla_x_preferred":[
+        "Port Vila"
+    ],
+    "name:gle_x_preferred":[
         "Port Vila"
     ],
     "name:glg_x_preferred":[
@@ -259,6 +271,9 @@
     "name:pan_x_preferred":[
         "\u0a2a\u0a4b\u0a30\u0a1f \u0a35\u0a3f\u0a32\u0a3e"
     ],
+    "name:pih_x_preferred":[
+        "Port Wiila"
+    ],
     "name:pms_x_preferred":[
         "Port Vila"
     ],
@@ -267,6 +282,9 @@
     ],
     "name:por_x_preferred":[
         "Port Vila"
+    ],
+    "name:por_x_variant":[
+        "Porto Vila"
     ],
     "name:pus_x_preferred":[
         "\u067e\u0648\u0631\u062a \u0648\u06cc\u0644\u0627"
@@ -523,7 +541,7 @@
         }
     ],
     "wof:id":890416453,
-    "wof:lastmodified":1607390883,
+    "wof:lastmodified":1690921636,
     "wof:name":"Port-Vila",
     "wof:parent_id":85680893,
     "wof:placetype":"locality",

--- a/data/890/436/677/890436677.geojson
+++ b/data/890/436/677/890436677.geojson
@@ -49,6 +49,12 @@
     "name:rus_x_preferred":[
         "\u041f\u043e\u0440\u0442 \u041e\u043b\u0440\u0438"
     ],
+    "name:spa_x_preferred":[
+        "Port Olry"
+    ],
+    "name:zho_x_preferred":[
+        "\u5967\u5229\u6e2f"
+    ],
     "qs:name":"Port-Olry",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -80,7 +86,7 @@
         }
     ],
     "wof:id":890436677,
-    "wof:lastmodified":1566652635,
+    "wof:lastmodified":1690921636,
     "wof:name":"Port-Olry",
     "wof:parent_id":85680875,
     "wof:placetype":"locality",

--- a/data/890/438/693/890438693.geojson
+++ b/data/890/438/693/890438693.geojson
@@ -22,6 +22,9 @@
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0421\u043e\u043b\u0430"
     ],
+    "name:bel_x_variant":[
+        "\u0421\u043e\u043b\u0430"
+    ],
     "name:bis_x_preferred":[
         "Sola"
     ],
@@ -100,7 +103,7 @@
         }
     ],
     "wof:id":890438693,
-    "wof:lastmodified":1566652635,
+    "wof:lastmodified":1690921636,
     "wof:name":"Sola",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/452/723/890452723.geojson
+++ b/data/890/452/723/890452723.geojson
@@ -22,6 +22,9 @@
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0406\u0441\u0430\u043d\u0433\u0435\u043b"
     ],
+    "name:bel_x_variant":[
+        "\u0406\u0441\u0430\u043d\u0433\u0435\u043b"
+    ],
     "name:bis_x_preferred":[
         "Isangel"
     ],
@@ -119,7 +122,7 @@
         }
     ],
     "wof:id":890452723,
-    "wof:lastmodified":1566652635,
+    "wof:lastmodified":1690921635,
     "wof:name":"Isangel",
     "wof:parent_id":85680881,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.