### PR TITLE
vu concordances, placetype local, and more

### DIFF
--- a/data/856/322/63/85632263.geojson
+++ b/data/856/322/63/85632263.geojson
@@ -1065,6 +1065,7 @@
         "hasc:id":"VU",
         "icao:code":"YJ",
         "ioc:id":"VAN",
+        "iso:code":"VU",
         "itu:id":"VUT",
         "loc:id":"n81088147",
         "m49:code":"548",
@@ -1079,6 +1080,7 @@
         "wk:page":"Vanuatu",
         "wmo:id":"NV"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"VU",
     "wof:country_alpha3":"VUT",
     "wof:geom_alt":[
@@ -1103,7 +1105,7 @@
         "eng",
         "fra"
     ],
-    "wof:lastmodified":1694639561,
+    "wof:lastmodified":1695881220,
     "wof:name":"Vanuatu",
     "wof:parent_id":102191583,
     "wof:placetype":"country",

--- a/data/856/808/71/85680871.geojson
+++ b/data/856/808/71/85680871.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.06788,
-    "geom:area_square_m":814781094.048769,
+    "geom:area_square_m":814781041.111291,
     "geom:bbox":"166.520518,-14.31992,167.716645,-13.064874",
     "geom:latitude":-13.894269,
     "geom:longitude":167.385217,
@@ -287,14 +287,16 @@
         "gn:id":2137421,
         "gp:id":20069883,
         "hasc:id":"VU.TR",
+        "iso:code":"VU-TOB",
         "iso:id":"VU-TOB",
         "qs_pg:id":1178415,
         "unlc:id":"VU-TOB",
         "wd:id":"Q822514",
         "wk:page":"Torba Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"VU",
-    "wof:geomhash":"4735c04c635b68b780e16a47d1d5c48d",
+    "wof:geomhash":"e86403bd828b3e0c0a83f722e9045004",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -313,7 +315,7 @@
         "eng",
         "fra"
     ],
-    "wof:lastmodified":1690921633,
+    "wof:lastmodified":1695884956,
     "wof:name":"Torba",
     "wof:parent_id":85632263,
     "wof:placetype":"region",

--- a/data/856/808/75/85680875.geojson
+++ b/data/856/808/75/85680875.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.364083,
-    "geom:area_square_m":4343303816.585856,
+    "geom:area_square_m":4343305133.481791,
     "geom:bbox":"166.522634,-15.751235,167.247244,-14.625258",
     "geom:latitude":-15.254289,
     "geom:longitude":166.871465,
@@ -287,14 +287,16 @@
         "gn:id":2134898,
         "gp:id":20069884,
         "hasc:id":"VU.SN",
+        "iso:code":"VU-SAM",
         "iso:id":"VU-SAM",
         "qs_pg:id":1184886,
         "unlc:id":"VU-SAM",
         "wd:id":"Q740640",
         "wk:page":"Sanma Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"VU",
-    "wof:geomhash":"fbe05b7721f2c60370c345ab0ff41b57",
+    "wof:geomhash":"438cd577ac48b54185e8e15f4204cf3c",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -313,7 +315,7 @@
         "eng",
         "fra"
     ],
-    "wof:lastmodified":1690921631,
+    "wof:lastmodified":1695884956,
     "wof:name":"Sanma",
     "wof:parent_id":85632263,
     "wof:placetype":"region",

--- a/data/856/808/81/85680881.geojson
+++ b/data/856/808/81/85680881.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.139769,
-    "geom:area_square_m":1632193979.271445,
+    "geom:area_square_m":1632193892.009336,
     "geom:bbox":"168.98227,-20.253106,169.898936,-18.618259",
     "geom:latitude":-19.188794,
     "geom:longitude":169.274842,
@@ -282,13 +282,15 @@
         "gn:id":2134739,
         "gp:id":20069887,
         "hasc:id":"VU.TF",
+        "iso:code":"VU-TAE",
         "iso:id":"VU-TAE",
         "qs_pg:id":892861,
         "wd:id":"Q576417",
         "wk:page":"Tafea Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"VU",
-    "wof:geomhash":"3e6051e0e5eb403b18edb824b7be7241",
+    "wof:geomhash":"950eabb5840f5925137934b811c9cd35",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -307,7 +309,7 @@
         "eng",
         "fra"
     ],
-    "wof:lastmodified":1690921632,
+    "wof:lastmodified":1695884956,
     "wof:name":"Tafea",
     "wof:parent_id":85632263,
     "wof:placetype":"region",

--- a/data/856/808/83/85680883.geojson
+++ b/data/856/808/83/85680883.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.241125,
-    "geom:area_square_m":2862240397.135101,
+    "geom:area_square_m":2862240986.063005,
     "geom:bbox":"167.144216,-16.587335,168.361339,-15.867364",
     "geom:latitude":-16.263563,
     "geom:longitude":167.649838,
@@ -284,14 +284,16 @@
         "gn:id":2208265,
         "gp:id":20069886,
         "hasc:id":"VU.ML",
+        "iso:code":"VU-MAP",
         "iso:id":"VU-MAP",
         "qs_pg:id":343870,
         "unlc:id":"VU-MAP",
         "wd:id":"Q740656",
         "wk:page":"Malampa Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"VU",
-    "wof:geomhash":"c01e4bfd606e936584c6d90dbc5154d2",
+    "wof:geomhash":"267683270de0775774d70c3b1d045edb",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -310,7 +312,7 @@
         "eng",
         "fra"
     ],
-    "wof:lastmodified":1690921632,
+    "wof:lastmodified":1695884956,
     "wof:name":"Malampa",
     "wof:parent_id":85632263,
     "wof:placetype":"region",

--- a/data/856/808/87/85680887.geojson
+++ b/data/856/808/87/85680887.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.102266,
-    "geom:area_square_m":1218634530.017439,
+    "geom:area_square_m":1218634275.646873,
     "geom:bbox":"167.672862,-15.992446,168.270356,-14.915785",
     "geom:latitude":-15.483539,
     "geom:longitude":168.050771,
@@ -280,13 +280,15 @@
         "gn:id":2208266,
         "gp:id":20069885,
         "hasc:id":"VU.PM",
+        "iso:code":"VU-PAM",
         "iso:id":"VU-PAM",
         "qs_pg:id":1184930,
         "wd:id":"Q836649",
         "wk:page":"Penama Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"VU",
-    "wof:geomhash":"6e346c7ace9097a01a9b3fcf523b3cba",
+    "wof:geomhash":"3b6a7e8b0c0005375ec07c6efb61ac3b",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -305,7 +307,7 @@
         "eng",
         "fra"
     ],
-    "wof:lastmodified":1690921631,
+    "wof:lastmodified":1695884956,
     "wof:name":"Penama",
     "wof:parent_id":85632263,
     "wof:placetype":"region",

--- a/data/856/808/93/85680893.geojson
+++ b/data/856/808/93/85680893.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.124431,
-    "geom:area_square_m":1468608141.874684,
+    "geom:area_square_m":1468607049.364731,
     "geom:bbox":"168.120372,-17.823663,168.597016,-16.573012",
     "geom:latitude":-17.344022,
     "geom:longitude":168.343008,
@@ -289,13 +289,15 @@
         "gn:id":2208267,
         "gp:id":20069888,
         "hasc:id":"VU.SE",
+        "iso:code":"VU-SEE",
         "iso:id":"VU-SEE",
         "qs_pg:id":223735,
         "wd:id":"Q650617",
         "wk:page":"Shefa Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"VU",
-    "wof:geomhash":"f415250ed2f861fd7bd2b111c5b4bf1e",
+    "wof:geomhash":"92e869cd6f5b6f7e2c2ac9f9ed99566d",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -314,7 +316,7 @@
         "eng",
         "fra"
     ],
-    "wof:lastmodified":1690921630,
+    "wof:lastmodified":1695884956,
     "wof:name":"Shefa",
     "wof:parent_id":85632263,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.